### PR TITLE
[INJICERT-41] rename fields to match draft-13 requirements

### DIFF
--- a/certify-service/src/main/resources/application-local.properties
+++ b/certify-service/src/main/resources/application-local.properties
@@ -66,7 +66,7 @@ mosip.certify.vci.key-values={\
                       'id': 'LifeInsuranceCredential', \
                       'scope' : 'life_insurance_vc_ldp',\
                       'cryptographic_binding_methods_supported': {'did:jwk'},\
-                      'cryptographic_suites_supported': {'Ed25519Signature2020'},\
+                      'credential_signing_alg_values_supported': {'Ed25519Signature2020'},\
                       'proof_types_supported': {'jwt'},\
                       'credential_definition': {\
                           'type': {'VerifiableCredential'},\
@@ -94,12 +94,12 @@ mosip.certify.vci.key-values={\
               'credential_issuer': '${mosipbox.public.url}',   \
               'credential_endpoint': '${mosipbox.public.url}${server.servlet.path}/vci/credential', \
               'display': {{'name': 'Insurance', 'locale': 'en'}},\
-              'credentials_supported' : { \
+              'credential_configurations_supported' : { \
                  "InsuranceCredential" : {\
                     'format': 'ldp_vc',\
                     'scope' : 'sunbird_rc_insurance_vc_ldp',\
                     'cryptographic_binding_methods_supported': {'did:jwk'},\
-                    'cryptographic_suites_supported': {'Ed25519Signature2020'},\
+                    'credential_signing_alg_values_supported': {'Ed25519Signature2020'},\
                     'proof_types_supported': {'jwt'},\
                     'credential_definition': {\
                       'type': {'VerifiableCredential','InsuranceCredential'},\
@@ -126,7 +126,7 @@ mosip.certify.vci.key-values={\
                       'format': 'ldp_vc',\
                       'scope' : 'life_insurance_vc_ldp',\
                       'cryptographic_binding_methods_supported': {'did:jwk'},\
-                      'cryptographic_suites_supported': {'Ed25519Signature2020'},\
+                      'credential_signing_alg_values_supported': {'Ed25519Signature2020'},\
                       'proof_types_supported': {'jwt'},\
                       'credential_definition': {\
                           'type': {'VerifiableCredential'},\

--- a/certify-service/src/test/java/io/mosip/certify/controller/VCIssuanceControllerTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/controller/VCIssuanceControllerTest.java
@@ -51,7 +51,7 @@ public class VCIssuanceControllerTest {
         Map<String, Object> issuerMetadata = new HashMap<>();
         issuerMetadata.put("credential_issuer", "https://localhost:9090");
         issuerMetadata.put("credential_endpoint", "https://localhost:9090/v1/certify/vci/credential");
-        issuerMetadata.put("credentials_supported", Arrays.asList());
+        issuerMetadata.put("credential_configurations_supported", Arrays.asList());
 
         Mockito.when(vcIssuanceService.getCredentialIssuerMetadata(Mockito.anyString())).thenReturn(issuerMetadata);
 
@@ -59,7 +59,7 @@ public class VCIssuanceControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.credential_issuer").exists())
                 .andExpect(jsonPath("$.credential_issuer").exists())
-                .andExpect(jsonPath("$.credentials_supported").exists())
+                .andExpect(jsonPath("$.credential_configurations_supported").exists())
                 .andExpect(header().string("Content-Type", "application/json"));
 
         Mockito.verify(vcIssuanceService).getCredentialIssuerMetadata("latest");
@@ -70,7 +70,7 @@ public class VCIssuanceControllerTest {
         Map<String, Object> issuerMetadata = new HashMap<>();
         issuerMetadata.put("credential_issuer", "https://localhost:9090");
         issuerMetadata.put("credential_endpoint", "https://localhost:9090/v1/certify/vci/credential");
-        issuerMetadata.put("credentials_supported", Arrays.asList());
+        issuerMetadata.put("credential_configurations_supported", Arrays.asList());
 
         Mockito.when(vcIssuanceService.getCredentialIssuerMetadata(Mockito.anyString())).thenReturn(issuerMetadata);
 
@@ -78,7 +78,7 @@ public class VCIssuanceControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.credential_issuer").exists())
                 .andExpect(jsonPath("$.credential_issuer").exists())
-                .andExpect(jsonPath("$.credentials_supported").exists())
+                .andExpect(jsonPath("$.credential_configurations_supported").exists())
                 .andExpect(header().string("Content-Type", "application/json"));
 
         Mockito.verify(vcIssuanceService).getCredentialIssuerMetadata("v11");

--- a/certify-service/src/test/resources/application-test.properties
+++ b/certify-service/src/test/resources/application-test.properties
@@ -57,12 +57,12 @@ mosip.certify.vci.key-values={\
               'credential_issuer': '${mosipbox.public.url}', 	\
               'credential_endpoint': '${mosipbox.public.url}${server.servlet.path}/vci/credential', \
               'display': {{'name': 'e-Signet', 'locale': 'en'}},\
-              'credentials_supported' : { \
+              'credential_configurations_supported' : { \
                  "SampleVerifiableCredential_ldp" : {\
                     'format': 'ldp_vc',\
                     'scope' : 'sample_vc_ldp',\
                     'cryptographic_binding_methods_supported': {'did:jwk'},\
-                    'cryptographic_suites_supported': {'RsaSignature2018'},\
+                    'credential_signing_alg_values_supported': {'RsaSignature2018'},\
                     'proof_types_supported': {'jwt'},\
                     'credential_definition': {\
                     'type': {'VerifiableCredential','SampleVerifiableCredential'},\

--- a/docker-compose/docker-compose-esignet/config/esignet-default.properties
+++ b/docker-compose/docker-compose-esignet/config/esignet-default.properties
@@ -491,12 +491,12 @@ mosip.esignet.vci.key-values={\
               'credential_issuer': '${mosip.esignet.vci.identifier}',   \
               'credential_endpoint': '${mosip.esignet.domain.url}${server.servlet.path}/vci/credential', \
               'display': {{'name': 'Insurance', 'locale': 'en'}},\
-              'credentials_supported' : { \
+              'credential_configurations_supported' : { \
                  "InsuranceCredential" : {\
                     'format': 'ldp_vc',\
                     'scope' : 'sunbird_rc_insurance_vc_ldp',\
                     'cryptographic_binding_methods_supported': {'did:jwk'},\
-                    'cryptographic_suites_supported': {'Ed25519Signature2020'},\
+                    'credential_signing_alg_values_supported': {'Ed25519Signature2020'},\
                     'proof_types_supported': {'jwt'},\
                     'credential_definition': {\
                       'type': {'VerifiableCredential','InsuranceCredential'},\
@@ -523,7 +523,7 @@ mosip.esignet.vci.key-values={\
                       'format': 'ldp_vc',\
                       'scope' : 'life_insurance_vc_ldp',\
                       'cryptographic_binding_methods_supported': {'did:jwk'},\
-                      'cryptographic_suites_supported': {'Ed25519Signature2020'},\
+                      'credential_signing_alg_values_supported': {'Ed25519Signature2020'},\
                       'proof_types_supported': {'jwt'},\
                       'credential_definition': {\
                           'type': {'VerifiableCredential'},\

--- a/vci-service-impl/src/main/java/io/mosip/certify/vci/services/VCIssuanceServiceImpl.java
+++ b/vci-service-impl/src/main/java/io/mosip/certify/vci/services/VCIssuanceServiceImpl.java
@@ -183,7 +183,7 @@ public class VCIssuanceServiceImpl implements VCIssuanceService {
     private Optional<CredentialMetadata>  getScopeCredentialMapping(String scope) {
         LinkedHashMap<String, Object> vciMetadata = issuerMetadata.get("latest");
         if(supportedCredentials == null) {
-            supportedCredentials = (LinkedHashMap<String, Object>) vciMetadata.get("credentials_supported");
+            supportedCredentials = (LinkedHashMap<String, Object>) vciMetadata.get("credential_configurations_supported");
         }
 
         Optional<Map.Entry<String, Object>> result = supportedCredentials.entrySet().stream()


### PR DESCRIPTION
*Renames* for draft-v13:

- cryptographic_suites_supported -> credential_signing_alg_values_supported
- credentials_supported          -> credential_configurations_supported

* older issuer metadata compatibility is still maintained